### PR TITLE
feat: debounce search input to improve UI stability

### DIFF
--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -9,6 +9,7 @@ import { BookmarkList } from "@/components/bookmark-list";
 import { BookmarkListSkeleton } from "@/components/dashboard-skeleton";
 import { parseColor, isUrl, normalizeUrl } from "@/lib/utils";
 import { client } from "@/lib/orpc";
+import { useDebounce } from "@/hooks/use-debounce";
 import type {
   BookmarkType,
   GroupItem,
@@ -31,6 +32,7 @@ export function DashboardContent({
 
   const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
   const [selectedIndex, setSelectedIndex] = useState<number>(-1);
   const [hoveredIndex, setHoveredIndex] = useState<number>(-1);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -181,13 +183,13 @@ export function DashboardContent({
 
   const filteredBookmarks = useMemo(() => {
     return bookmarks.filter((b) => {
-      if (!searchQuery) return true;
+      if (!debouncedSearchQuery) return true;
       return (
-        b.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        b.url?.toLowerCase().includes(searchQuery.toLowerCase())
+        b.title.toLowerCase().includes(debouncedSearchQuery.toLowerCase()) ||
+        b.url?.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
       );
     });
-  }, [bookmarks, searchQuery]);
+  }, [bookmarks, debouncedSearchQuery]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/hooks/use-debounce.ts
+++ b/hooks/use-debounce.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Debounces a value by delaying updates until after the specified delay
+ * has passed since the last change.
+ *
+ * @param value - The value to debounce
+ * @param delay - The delay in milliseconds (default: 300ms)
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
Add 300ms debounce to search filtering to prevent the bookmark list from jumping around while typing. The input remains responsive while the filtering only triggers after the user pauses.