### PR TITLE
fix: single bookmark for multiline paste and truncate long titles

### DIFF
--- a/components/bookmark-list.tsx
+++ b/components/bookmark-list.tsx
@@ -195,7 +195,7 @@ export function BookmarkList({
                       }}
                     />
                   ) : (
-                    <span className="text-sm font-normal">
+                    <span className="text-sm font-normal truncate">
                       {copiedId === bookmark.id ? "Copied" : bookmark.title}
                     </span>
                   )}

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -278,42 +278,35 @@ export function DashboardContent({
     (value: string) => {
       if (!currentGroupId) return;
 
-      const lines = value
-        .split("\n")
-        .map((l) => l.trim())
-        .filter(Boolean);
+      const trimmedValue = value.trim();
+      if (!trimmedValue) return;
 
-      lines.forEach((line) => {
-        const colorResult = parseColor(line);
-        if (colorResult.isColor) {
-          createBookmarkMutation.mutate({
-            title: colorResult.original || line,
-            url: "",
-            type: "color",
-            color: colorResult.hex,
-            groupId: currentGroupId,
-          });
-          return;
-        }
+      const colorResult = parseColor(trimmedValue);
 
-        if (isUrl(line)) {
-          const url = normalizeUrl(line);
-          createBookmarkMutation.mutate({
-            title: new URL(url).hostname.replace("www.", ""),
-            url,
-            type: "link",
-            groupId: currentGroupId,
-          });
-          return;
-        }
-
+      if (colorResult.isColor) {
         createBookmarkMutation.mutate({
-          title: line,
+          title: colorResult.original || trimmedValue,
+          url: "",
+          type: "color",
+          color: colorResult.hex,
+          groupId: currentGroupId,
+        });
+      } else if (!trimmedValue.includes("\n") && isUrl(trimmedValue)) {
+        const url = normalizeUrl(trimmedValue);
+        createBookmarkMutation.mutate({
+          title: new URL(url).hostname.replace("www.", ""),
+          url,
+          type: "link",
+          groupId: currentGroupId,
+        });
+      } else {
+        createBookmarkMutation.mutate({
+          title: trimmedValue,
           url: "",
           type: "text",
           groupId: currentGroupId,
         });
-      });
+      }
 
       setSearchQuery("");
       setSelectedIndex(-1);


### PR DESCRIPTION
- Changed handleAddBookmark to create one bookmark for multiline content
  instead of splitting by newlines and creating multiple bookmarks
- Added truncate class to bookmark title to prevent text overflow