### PR TITLE
feat: split dashboard into separate route with cached landing

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,71 @@
+import { Suspense } from "react";
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth-server";
+import { db } from "@/lib/db";
+import { DashboardContent } from "@/components/dashboard-content";
+import type { GroupItem, BookmarkItem } from "@/lib/schema";
+
+async function DashboardData() {
+  const session = await getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  const groups = await db.group.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "asc" },
+    include: {
+      _count: {
+        select: { bookmarks: true },
+      },
+    },
+  });
+
+  const groupItems: GroupItem[] = groups.map((g) => ({
+    id: g.id,
+    name: g.name,
+    color: g.color,
+    bookmarkCount: g._count.bookmarks,
+  }));
+
+  const defaultGroupId = groups[0]?.id;
+  let initialBookmarks: BookmarkItem[] = [];
+
+  if (defaultGroupId) {
+    const bookmarks = await db.bookmark.findMany({
+      where: {
+        userId: session.user.id,
+        groupId: defaultGroupId,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    initialBookmarks = bookmarks.map((b) => ({
+      id: b.id,
+      title: b.title,
+      url: b.url,
+      favicon: b.favicon,
+      type: b.type,
+      color: b.color,
+      groupId: b.groupId,
+      createdAt: b.createdAt,
+    }));
+  }
+
+  return (
+    <DashboardContent
+      session={session}
+      initialGroups={groupItems}
+      initialBookmarks={initialBookmarks}
+    />
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <Suspense>
+      <DashboardData />
+    </Suspense>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,71 +1,10 @@
-import { Suspense } from "react";
-import { getSession } from "@/lib/auth-server";
-import { db } from "@/lib/db";
 import { Landing } from "@/components/landing";
-import { DashboardContent } from "@/components/dashboard-content";
-import type { GroupItem, BookmarkItem } from "@/lib/schema";
 
-async function HomeContent() {
-  const session = await getSession();
-
-  if (!session) {
-    return <Landing />;
-  }
-
-  const groups = await db.group.findMany({
-    where: { userId: session.user.id },
-    orderBy: { createdAt: "asc" },
-    include: {
-      _count: {
-        select: { bookmarks: true },
-      },
-    },
-  });
-
-  const groupItems: GroupItem[] = groups.map((g) => ({
-    id: g.id,
-    name: g.name,
-    color: g.color,
-    bookmarkCount: g._count.bookmarks,
-  }));
-
-  const defaultGroupId = groups[0]?.id;
-  let initialBookmarks: BookmarkItem[] = [];
-
-  if (defaultGroupId) {
-    const bookmarks = await db.bookmark.findMany({
-      where: {
-        userId: session.user.id,
-        groupId: defaultGroupId,
-      },
-      orderBy: { createdAt: "desc" },
-    });
-
-    initialBookmarks = bookmarks.map((b) => ({
-      id: b.id,
-      title: b.title,
-      url: b.url,
-      favicon: b.favicon,
-      type: b.type,
-      color: b.color,
-      groupId: b.groupId,
-      createdAt: b.createdAt,
-    }));
-  }
-
-  return (
-    <DashboardContent
-      session={session}
-      initialGroups={groupItems}
-      initialBookmarks={initialBookmarks}
-    />
-  );
+async function CachedLanding() {
+  "use cache";
+  return <Landing />;
 }
 
 export default function Page() {
-  return (
-    <Suspense>
-      <HomeContent />
-    </Suspense>
-  );
+  return <CachedLanding />;
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionCookie } from "better-auth/cookies";
+
+export function proxy(request: NextRequest) {
+  const sessionCookie = getSessionCookie(request);
+
+  if (sessionCookie && request.nextUrl.pathname === "/") {
+    return NextResponse.redirect(new URL("/dashboard", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/"],
+};


### PR DESCRIPTION
- Add proxy.ts for Next.js 16 auth-based routing (/ → /dashboard)
- Simplify app/page.tsx to cached static landing page
- Create app/dashboard/page.tsx with Suspense boundary for dynamic content
- Fix blocking route error by isolating dynamic session checks