### PR TITLE
fix(bulk-select): stop pointer event propagation on checkbox to prevent double-toggle

### DIFF
--- a/components/bookmark-list.tsx
+++ b/components/bookmark-list.tsx
@@ -196,6 +196,7 @@ export function BookmarkList({
                       checked={selectedIds.has(bookmark.id)}
                       onCheckedChange={() => onToggleSelection?.(bookmark.id)}
                       onClick={(e) => e.stopPropagation()}
+                      onPointerDown={(e) => e.stopPropagation()}
                     />
                   ) : (
                     <BookmarkIcon


### PR DESCRIPTION
## Summary

Clicking directly on the checkbox in bulk select mode did not toggle selection because Base UI's Checkbox uses `pointerdown` internally, causing the parent button's click handler to also fire and double-toggle the selection back.

## Changes

- Added `onPointerDown={(e) => e.stopPropagation()}` to the `Checkbox` in `bookmark-list.tsx` to prevent the pointer event from bubbling to the parent row button

## Type of Change

- [x] fix: Bug fix

## Testing

Manually tested bulk select mode — clicking the checkbox now correctly toggles bookmark selection without requiring a click on the row itself.