### PR TITLE
improve group visibility UX and sort public profile by updated

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -37,7 +37,9 @@
       "Bash(npm pack geist@1.3.1)",
       "Bash(tar:*)",
       "Bash(command tar xzf /tmp/geist-1.3.1.tgz -C /tmp)",
-      "WebFetch(domain:localhost)"
+      "WebFetch(domain:localhost)",
+      "Bash(echo:*)",
+      "Bash(git push)"
     ],
     "deny": [],
     "ask": []

--- a/app/u/[username]/public-profile-content.tsx
+++ b/app/u/[username]/public-profile-content.tsx
@@ -24,7 +24,7 @@ interface PublicBookmark {
   type: string;
   color: string | null;
   groupName: string | null;
-  createdAt: Date | string;
+  updatedAt: Date | string;
 }
 
 interface PublicProfileContentProps {
@@ -199,7 +199,7 @@ export function PublicProfileContent({
             <>
               <div className="mb-2 flex items-center justify-between border-b border-border px-1 pb-2 text-sm text-muted-foreground">
                 <span>Title</span>
-                <span>Created At</span>
+                <span>Updated</span>
               </div>
               <div className="flex flex-col gap-0.5 -mx-3">
                 {filteredBookmarks.map((bookmark) => (
@@ -234,7 +234,7 @@ export function PublicProfileContent({
                             "transition-transform duration-200 group-hover:-translate-x-5",
                         )}
                       >
-                        {formatDate(bookmark.createdAt)}
+                        {formatDate(bookmark.updatedAt)}
                       </span>
                       {bookmark.url && (
                         <svg

--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -672,6 +672,9 @@ export function DashboardContent({
 
       return { previousGroups };
     },
+    onSuccess: (_data, variables) => {
+      toast.success(variables.isPublic ? "Group is now public" : "Group is now private");
+    },
     onError: (_err, _data, context) => {
       if (context?.previousGroups) {
         queryClient.setQueryData<GroupItem[]>(groupListKey(), context.previousGroups);
@@ -956,7 +959,6 @@ export function DashboardContent({
   const handleToggleGroupVisibility = useCallback(
     (id: string, isPublic: boolean) => {
       setGroupVisibilityMutation.mutate({ id, isPublic });
-      toast.success(isPublic ? "Group is now public" : "Group is now private");
     },
     [setGroupVisibilityMutation],
   );
@@ -1061,6 +1063,7 @@ export function DashboardContent({
         onCreateGroup={handleCreateGroup}
         onDeleteGroup={handleDeleteGroup}
         onToggleGroupVisibility={hasUsername ? handleToggleGroupVisibility : undefined}
+        isTogglingGroupVisibility={setGroupVisibilityMutation.isPending}
         userName={session.user.name}
         userEmail={session.user.email}
         username={profile.username}
@@ -1111,8 +1114,8 @@ export function DashboardContent({
             onDelete={() => setDeleteDialogOpen(true)}
             onClose={handleExitSelectionMode}
             hasUsername={hasUsername}
-            onMakePublic={handleBulkMakePublic}
-            onMakePrivate={handleBulkMakePrivate}
+            onMakePublic={currentGroupId && publicGroupIds.has(currentGroupId) ? undefined : handleBulkMakePublic}
+            onMakePrivate={currentGroupId && publicGroupIds.has(currentGroupId) ? handleBulkMakePrivate : undefined}
           />
         )}
         <BulkMoveDialog

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -31,6 +31,7 @@ import {
   IconWorld,
   IconWorldOff,
   IconUser,
+  IconLoader2,
 } from "@tabler/icons-react";
 import { signOut } from "@/lib/auth-client";
 import {
@@ -60,6 +61,7 @@ interface HeaderProps {
   onCreateGroup: (name: string) => void;
   onDeleteGroup?: (id: string) => void;
   onToggleGroupVisibility?: (id: string, isPublic: boolean) => void;
+  isTogglingGroupVisibility?: boolean;
   userName: string;
   userEmail: string;
   username?: string | null;
@@ -76,6 +78,7 @@ export function Header({
   onCreateGroup,
   onDeleteGroup,
   onToggleGroupVisibility,
+  isTogglingGroupVisibility,
   userName,
   userEmail,
   username,
@@ -95,6 +98,15 @@ export function Header({
   const [holdProgress, setHoldProgress] = useState(0);
   const holdTimerRef = useRef<NodeJS.Timeout | null>(null);
   const holdStartRef = useRef<number>(0);
+  const initiatedToggleRef = useRef(false);
+
+  useEffect(() => {
+    if (!isTogglingGroupVisibility && initiatedToggleRef.current) {
+      initiatedToggleRef.current = false;
+      setPublicDialogOpen(false);
+      setPendingPublicGroupId(null);
+    }
+  }, [isTogglingGroupVisibility]);
 
   const handleSignOut = async () => {
     await signOut();
@@ -371,7 +383,12 @@ export function Header({
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
-          <AlertDialog open={publicDialogOpen} onOpenChange={setPublicDialogOpen}>
+          <AlertDialog
+            open={publicDialogOpen}
+            onOpenChange={(open) => {
+              if (!isTogglingGroupVisibility) setPublicDialogOpen(open);
+            }}
+          >
             <AlertDialogContent>
               <AlertDialogHeader>
                 <AlertDialogTitle className="font-semibold text-xl">
@@ -382,17 +399,30 @@ export function Header({
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
-                <AlertDialogCancel variant="ghost">Cancel</AlertDialogCancel>
-                <AlertDialogAction
+                <Button
+                  variant="ghost"
+                  disabled={isTogglingGroupVisibility}
                   onClick={() => {
-                    if (pendingPublicGroupId) {
-                      onToggleGroupVisibility?.(pendingPublicGroupId, true);
-                    }
+                    setPublicDialogOpen(false);
                     setPendingPublicGroupId(null);
                   }}
                 >
+                  Cancel
+                </Button>
+                <Button
+                  disabled={isTogglingGroupVisibility}
+                  onClick={() => {
+                    if (pendingPublicGroupId) {
+                      onToggleGroupVisibility?.(pendingPublicGroupId, true);
+                      initiatedToggleRef.current = true;
+                    }
+                  }}
+                >
+                  {isTogglingGroupVisibility && (
+                    <IconLoader2 className="h-4 w-4 animate-spin" />
+                  )}
                   Make Public
-                </AlertDialogAction>
+                </Button>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>

--- a/server/queries/public-profile.ts
+++ b/server/queries/public-profile.ts
@@ -26,7 +26,7 @@ const bookmarkSelect = {
   type: true,
   color: true,
   groupId: true,
-  createdAt: true,
+  updatedAt: true,
 } as const;
 
 export const getPublicProfileData = cache(async (username: string) => {
@@ -51,7 +51,7 @@ export const getPublicProfileData = cache(async (username: string) => {
           { isPublic: true },
         ],
       },
-      orderBy: { createdAt: "desc" },
+      orderBy: { updatedAt: "desc" },
       select: bookmarkSelect,
     }),
   ]);


### PR DESCRIPTION
- Add loading spinner to "Make Public" dialog, move toast to onSuccess
- Auto-close dialog on mutation completion via ref-tracked useEffect
- Show only relevant toggle (Public/Private) in multiselect toolbar
- Sort public profile bookmarks by updatedAt instead of createdAt