### PR TITLE
Normalize interactive blog group slugs across profile routes

### DIFF
--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { ImageResponse } from "next/og";
 import type { NextRequest } from "next/server";
 import { getPublicProfileData } from "@/server/queries/public-profile";
+import { slugify } from "@/lib/utils";
 
 const colors = {
   bg: "#ffffff",
@@ -160,7 +161,13 @@ export async function GET(request: NextRequest) {
     return Response.json({ error: "Not found" }, { status: 404 });
   }
 
-  const group = data.groups.find((g) => g.name === searchParams.get("group"));
+  const groupParam = searchParams.get("group");
+  const groups = data.groups as Array<{ name: string; color: string }>;
+  const group = groupParam
+    ? groups.find(
+      (entry) => slugify(entry.name) === groupParam || entry.name === groupParam,
+    )
+    : undefined;
   const heroText = group ? group.name : data.user.name;
   const subtitle = group
     ? `by @${data.user.username}`

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import type { Metadata } from "next";
 import { getPublicProfileData } from "@/server/queries/public-profile";
 import { getSession } from "@/lib/auth-server";
+import { slugify } from "@/lib/utils";
 import { PublicProfileContent } from "./public-profile-content";
 
 interface PageProps {
@@ -26,7 +27,14 @@ export async function generateMetadata({
 
   if (!data) return {};
 
-  const group = resolveGroupParam(resolvedSearchParams?.group);
+  const groupParam = resolveGroupParam(resolvedSearchParams?.group);
+  const groups = data.groups as Array<{ name: string }>;
+  const matchingGroup = groupParam
+    ? groups.find(
+      (group) => slugify(group.name) === groupParam || group.name === groupParam,
+    )
+    : undefined;
+  const group = matchingGroup ? slugify(matchingGroup.name) : groupParam;
 
   const title = `${data.user.name} (@${data.user.username}) — bmrks`;
   const description =


### PR DESCRIPTION
Summary
- align OG route lookup with slugified group names so URLs like `interactive-blogs` resolve consistently
- normalize public profile metadata and tabs around slugified group identifiers, keeping query state in sync with generated slugs
- keep bookmark filtering keyed to the normalized group slug

Testing
- Not run (not requested)