### PR TITLE
fix: resolve all 15 ESLint errors and warnings

### DIFF
--- a/components/dashboard-content.tsx
+++ b/components/dashboard-content.tsx
@@ -72,6 +72,7 @@ export function DashboardContent({
   profile,
 }: DashboardContentProps) {
   const queryClient = useQueryClient();
+  const [mountedAt] = useState(Date.now);
 
   const [groupSlug, setGroupSlug] = useQueryState("group");
   const [searchQuery, setSearchQuery] = useState("");
@@ -89,7 +90,7 @@ export function DashboardContent({
   const groupsQuery = useQuery({
     ...orpc.group.list.queryOptions(),
     initialData: initialGroups,
-    initialDataUpdatedAt: Date.now(),
+    initialDataUpdatedAt: mountedAt,
   });
 
   const groups = useMemo(() => groupsQuery.data ?? [], [groupsQuery.data]);
@@ -114,8 +115,6 @@ export function DashboardContent({
     () => new Map(groups.map((g) => [slugify(g.name), g.id])),
     [groups],
   );
-  const groupIdBySlugRef = useLatestRef(groupIdBySlug);
-
   const selectedGroupId = groupSlug
     ? (groupIdBySlug.get(groupSlug) ?? null)
     : null;
@@ -128,7 +127,7 @@ export function DashboardContent({
     }),
     initialData:
       currentGroupId === initialGroups[0]?.id ? initialBookmarks : undefined,
-    initialDataUpdatedAt: Date.now(),
+    initialDataUpdatedAt: mountedAt,
     enabled: !!currentGroupId,
   });
 
@@ -926,8 +925,6 @@ export function DashboardContent({
   const handleDeleteBookmarkRef = useLatestRef(handleDeleteBookmark);
   const handleStartRenameRef = useLatestRef(handleStartRename);
   const selectionModeRef = useLatestRef(selectionMode);
-  const selectedIdsRef = useLatestRef(selectedIds);
-
   const handleSearchChange = useCallback((value: string) => {
     setSearchQuery(value);
     setSelectedIndex(-1);
@@ -941,7 +938,7 @@ export function DashboardContent({
       setHoveredIndex(-1);
       handleExitSelectionMode();
     },
-    [setGroupSlug, handleExitSelectionMode],
+    [groupsRef, setGroupSlug, handleExitSelectionMode],
   );
 
   const handleAddBookmark = useCallback(
@@ -1194,7 +1191,18 @@ export function DashboardContent({
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleExitSelectionMode, handleSelectAll, handleToggleSelection]);
+  }, [
+    filteredBookmarksRef,
+    handleDeleteBookmarkRef,
+    handleStartRenameRef,
+    hoveredIndexRef,
+    renamingIdRef,
+    selectedIndexRef,
+    selectionModeRef,
+    handleExitSelectionMode,
+    handleSelectAll,
+    handleToggleSelection,
+  ]);
 
   if (!selectedGroup) {
     return null;
@@ -1257,7 +1265,6 @@ export function DashboardContent({
         )}
         {selectionMode && selectedIds.size > 0 && (
           <MultiSelectToolbar
-            selectedCount={selectedIds.size}
             onSelectAll={handleSelectAll}
             onMove={() => setMoveDialogOpen(true)}
             onCopyUrls={handleCopyUrls}

--- a/components/multi-select-toolbar.tsx
+++ b/components/multi-select-toolbar.tsx
@@ -22,7 +22,6 @@ import {
 } from "@tabler/icons-react";
 
 interface MultiSelectToolbarProps {
-  selectedCount: number;
   onSelectAll: () => void;
   onMove: () => void;
   onCopyUrls: () => void;
@@ -35,7 +34,6 @@ interface MultiSelectToolbarProps {
 }
 
 export function MultiSelectToolbar({
-  selectedCount,
   onSelectAll,
   onMove,
   onCopyUrls,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,19 @@ import nextTs from "eslint-config-next/typescript";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/lib/hooks/use-latest-ref.ts
+++ b/lib/hooks/use-latest-ref.ts
@@ -1,7 +1,9 @@
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 export function useLatestRef<T>(value: T) {
   const ref = useRef(value);
-  ref.current = value;
+  useEffect(() => {
+    ref.current = value;
+  });
   return ref;
 }

--- a/server/procedures/public.ts
+++ b/server/procedures/public.ts
@@ -13,7 +13,7 @@ export const getPublicProfile = base
     }
 
     const { user, groups, bookmarks } = data;
-    const { id, isProfilePublic, ...userFields } = user;
+    const { id: _id, isProfilePublic: _isProfilePublic, ...userFields } = user;
 
     return { user: userFields, groups, bookmarks };
   });


### PR DESCRIPTION
## Summary
- Fixed 3 ESLint errors (impure `Date.now()` during render, ref mutation during render) and 12 warnings (unused vars, missing hook deps)
- Configured `@typescript-eslint/no-unused-vars` to support `_` prefix convention for destructure-to-discard pattern
- Removed dead code: `groupIdBySlugRef`, `selectedIdsRef`, unused `selectedCount` prop

## Changes
| File | Fix |
|------|-----|
| `lib/hooks/use-latest-ref.ts` | Wrap `ref.current` write in `useEffect` (react-hooks/refs) |
| `components/dashboard-content.tsx` | Replace `Date.now()` with stable `mountedAt` state; remove unused refs; add missing deps |
| `components/multi-select-toolbar.tsx` | Remove unused `selectedCount` prop |
| `eslint.config.mjs` | Configure `_` prefix ignore for no-unused-vars |
| `server/procedures/public.ts` | Rename destructured vars with `_` prefix |

## Test plan
- [x] `npx eslint .` passes with 0 errors, 0 warnings
- [x] `npx tsc --noEmit` passes clean


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/Users/duncan/dev/bmrks
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 3.0
cost-tier: Low (10-50k)
iterations: 1
duration: 12m30s
run-started: 2026-02-16T23:14:08Z
nightshift:metadata -->
