### PR TITLE
feat: redesign bookmark list loading skeleton

### DIFF
--- a/components/dashboard-skeleton.tsx
+++ b/components/dashboard-skeleton.tsx
@@ -1,5 +1,6 @@
 import { HeaderSkeleton } from "@/components/header-skeleton";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 
 export function DashboardSkeleton() {
   return (
@@ -17,12 +18,38 @@ export function DashboardSkeleton() {
   );
 }
 
+const SKELETON_ROWS = [
+  { title: "w-44", date: "w-10" },
+  { title: "w-32", date: "w-16" },
+  { title: "w-56", date: "w-10" },
+  { title: "w-36", date: "w-12" },
+  { title: "w-48", date: "w-10" },
+  { title: "w-28", date: "w-14" },
+  { title: "w-52", date: "w-10" },
+  { title: "w-40", date: "w-12" },
+];
+
 export function BookmarkListSkeleton() {
   return (
-    <div className="space-y-1">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <Skeleton key={i} className="h-[46px] w-full rounded-xl" />
-      ))}
+    <div>
+      <div className="mb-2 flex items-center justify-between border-b border-border px-1 pb-2 text-sm text-muted-foreground">
+        <span>Title</span>
+        <span>Created At</span>
+      </div>
+      <div className="-mx-3 flex flex-col gap-0.5">
+        {SKELETON_ROWS.map((row, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between rounded-xl px-4 py-3"
+          >
+            <div className="mr-4 flex min-w-0 flex-1 items-center gap-2">
+              <Skeleton className="size-5 shrink-0 rounded" />
+              <Skeleton className={cn("h-4 rounded", row.title)} />
+            </div>
+            <Skeleton className={cn("h-3.5 rounded", row.date)} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## What

Redesigns the bookmark list loading skeleton (`BookmarkListSkeleton`) so it mirrors the real `BookmarkList` instead of showing flat full-width bars.

## Changes

- **Keep the "Title" / "Created At" header visible while loading** — previously it disappeared during the pending state; now the skeleton renders under it.
- **Rows mirror the real bookmark item**: favicon-shaped block (`size-5 rounded`, matching `FaviconImage`) + a title line + a right-aligned date block, using the same container/padding (`-mx-3`, `gap-0.5`, `px-4 py-3 rounded-xl`) so the swap to real content is seamless.
- **Natural varied widths** via a static `SKELETON_ROWS` table (deterministic → no hydration mismatch).
- Replaced arbitrary `h-[46px]` bars with semantic sizing (`size-5`, `h-4`, `h-3.5`); reused the existing `Skeleton` for a consistent pulse.

`DashboardSkeleton` left untouched (defined but never imported).

## Verification

- `tsc --noEmit` clean
- `eslint` clean